### PR TITLE
Fix missing closing bracket in Types.cs

### DIFF
--- a/TofuPatcher/Types.cs
+++ b/TofuPatcher/Types.cs
@@ -18,3 +18,4 @@ namespace TofuPatcher
     public sealed record FixedText<TValue>(TValue Original, TValue Fixed)
         where TValue : notnull;
 
+}


### PR DESCRIPTION
`Types.cs(19,32): error CS1513: } expected` 
Fixes #1 