### PR TITLE
Fix null dialogue prompts becoming empty string

### DIFF
--- a/TofuPatcher.Tests/Patcher.cs
+++ b/TofuPatcher.Tests/Patcher.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Aspects;
 using Mutagen.Bethesda.Skyrim;
+using Mutagen.Bethesda.Strings;
 
 namespace TofuPatcher.Tests;
 
@@ -12,8 +13,9 @@ public sealed record NamedGetter(string? Name) : INamedGetter
 
 public class NamedPatcherTests
 {
-    private static readonly NamedRecordTextPatcher _patcher =
-        new([TextUtil.ToAscii, str => str?.Trim()]);
+    private static readonly NamedRecordTextPatcher _patcher = new(
+        [TextUtil.ToAscii, str => str?.Trim()]
+    );
     public static object[][] FilterTestData =
     [
         [new NamedGetter(null), false],
@@ -49,8 +51,9 @@ public class NamedPatcherTests
 
 public class DialogueInfoPatcherTests
 {
-    private static readonly DialogueInfoTextPatcher _patcher =
-        new([TextUtil.ToAscii, str => str?.Trim()]);
+    private static readonly DialogueInfoTextPatcher _patcher = new(
+        [TextUtil.ToAscii, str => str?.Trim()]
+    );
 
     public static object[][] FilterTestData =
     [
@@ -75,15 +78,15 @@ public class DialogueInfoPatcherTests
         [
             Factory(null, []),
             new FixedText<DialogueInfoTexts>(
-                new DialogueInfoTexts(null, []),
-                new DialogueInfoTexts(null, [])
+                new DialogueInfoTexts((string?)null, []),
+                new DialogueInfoTexts((string?)null, [])
             ),
         ],
         [
             Factory(null, [" Response1 "]),
             new FixedText<DialogueInfoTexts>(
-                new DialogueInfoTexts(null, [" Response1 "]),
-                new DialogueInfoTexts(null, ["Response1"])
+                new DialogueInfoTexts((TranslatedString?)null, [" Response1 "]),
+                new DialogueInfoTexts((TranslatedString?)null, ["Response1"])
             ),
         ],
         [
@@ -117,8 +120,8 @@ public class DialogueInfoPatcherTests
         [
             Factory(null, [" Response1 "]),
             new FixedText<DialogueInfoTexts>(
-                new DialogueInfoTexts(null, [" Response1 "]),
-                new DialogueInfoTexts(null, ["Response1"])
+                new DialogueInfoTexts((string?)null, [" Response1 "]),
+                new DialogueInfoTexts((string?)null, ["Response1"])
             ),
             Factory(null, ["Response1"]),
         ],
@@ -152,10 +155,15 @@ public class DialogueInfoPatcherTests
         target.Should().Be(expected);
     }
 
-    private static IDialogResponses Factory(string? prompt, IEnumerable<string?> responses)
+    private static IDialogResponses Factory(
+        TranslatedString? prompt,
+        IEnumerable<string?> responses
+    )
     {
-        DialogResponses record =
-            new(FormKey.Factory("123456:Test.esp"), SkyrimRelease.SkyrimSE) { Prompt = prompt };
+        DialogResponses record = new(FormKey.Factory("123456:Test.esp"), SkyrimRelease.SkyrimSE)
+        {
+            Prompt = prompt,
+        };
         foreach (var responseText in responses)
         {
             DialogResponse response = new() { Text = responseText };

--- a/TofuPatcher/Program.cs
+++ b/TofuPatcher/Program.cs
@@ -11,7 +11,6 @@ namespace TofuPatcher
     public class Program
     {
         private static Lazy<TofuPatcherSettings> _settings = null!;
-        private static TofuPatcherSettings Settings => _settings.Value;
 
         public static async Task<int> Main(string[] args)
         {
@@ -28,11 +27,11 @@ namespace TofuPatcher
 
         public static void RunPatch(IPatcherState<ISkyrimMod, ISkyrimModGetter> state)
         {
-            var excludeMods = Settings.ExcludeMods.ToFrozenSet();
+            var excludeMods = _settings.Value.ExcludeMods.ToFrozenSet();
 
             // Add text transformations based on user settings
             var transforms = new List<Func<string?, string?>> { TextUtil.ToAscii };
-            if (Settings.TrimWhitespace)
+            if (_settings.Value.TrimWhitespace)
             {
                 transforms.Add(str => str?.Trim());
             }

--- a/TofuPatcher/Types.cs
+++ b/TofuPatcher/Types.cs
@@ -1,4 +1,5 @@
 using Badeend.ValueCollections;
+using Mutagen.Bethesda.Strings;
 
 namespace TofuPatcher
 {
@@ -7,7 +8,10 @@ namespace TofuPatcher
     /// </summary>
     /// <param name="Responses">The text string for each response in the record</param>
     /// <param name="Prompt">The prompt that triggers the responses</param>
-    public sealed record DialogueInfoTexts(string? Prompt, ValueList<string?> Responses);
+    public sealed record DialogueInfoTexts(
+        TranslatedStringWrapper Prompt,
+        ValueList<string?> Responses
+    );
 
     public sealed record BookTexts(string? Name, string? BookText);
 
@@ -18,4 +22,20 @@ namespace TofuPatcher
     public sealed record FixedText<TValue>(TValue Original, TValue Fixed)
         where TValue : notnull;
 
+    /// <summary>
+    /// Wrapper for TranslatedStrings due to weird operator conversion behavior with nulls
+    /// </summary>
+    /// <param name="Value">The underlying string value</param>
+    public sealed record TranslatedStringWrapper(string? Value)
+    {
+        public static implicit operator TranslatedStringWrapper(string? str) => new(str);
+
+        public static implicit operator string?(TranslatedStringWrapper wrapper) => wrapper.Value;
+
+        public static implicit operator TranslatedStringWrapper(TranslatedString? translated) =>
+            new(translated?.String);
+
+        public static implicit operator TranslatedString?(TranslatedStringWrapper wrapper) =>
+            wrapper.Value is null ? (TranslatedString?)null : wrapper.Value; // ?? does not work here even with cast
+    }
 }


### PR DESCRIPTION
Closes #5 

## Changes

- Added `TranslatedStringWrapper` to codify null-assignment behavior
- Updated `DialogueInfoTexts` and `DialogueInfoPatcher` to use wrapper